### PR TITLE
Add resources for GitHub certification to README and create recursos.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,10 @@ Este es un espacio abierto y comunitario para aprender a usar Git y GitHub en eq
 
 Podés proponer una idea en el archivo `ideas.md`. ¡Todo suma!
 
+## Recursos
+
+Encontrarás recursos útiles sobre certificación GitHub en el archivo [recursos.md](recursos.md).
+
 ## Reglas simples
 
 - Respetá a tus compañeros.

--- a/recursos.md
+++ b/recursos.md
@@ -1,0 +1,28 @@
+# Recursos para Certificación GitHub
+
+Este documento recopila recursos útiles para prepararse para la certificación GitHub.
+
+## Enlaces importantes
+
+- **Certificación GitHub Foundations**: La página oficial para registrarse al examen de certificación.  
+  [https://examregistration.github.com/certification](https://examregistration.github.com/certification)
+
+- **Guía de Estudios**: Artículo del blog de Microsoft con orientación para preparar la certificación.  
+  [https://techcommunity.microsoft.com/blog/educatordeveloperblog/%C2%A1gu%C3%ADa-de-estudios-para-la-certificaci%C3%B3n-github-foundations/4176639](https://techcommunity.microsoft.com/blog/educatordeveloperblog/%C2%A1gu%C3%ADa-de-estudios-para-la-certificaci%C3%B3n-github-foundations/4176639)
+
+- **Manual del Examen**: Documento oficial con información sobre el formato y políticas del examen.  
+  [https://examregistration.github.com/handbook](https://examregistration.github.com/handbook)
+
+- **Guía de Estudios Gratuita**: Recurso gratuito para preparar la certificación.  
+  [aka.ms/GuiaEstudioGF](https://aka.ms/GuiaEstudioGF)
+
+- **Guía Completa en GitHub**: Repositorio con información detallada sobre la certificación.  
+  [https://github.com/LadyKerr/github-certification-guide](https://github.com/LadyKerr/github-certification-guide?tab=readme-ov-file)
+
+- **Discusión de Preparación**: Conversación comunitaria sobre la preparación para el examen.  
+  [https://github.com/orgs/community/discussions/154502#discussioncomment-12751631](https://github.com/orgs/community/discussions/154502#discussioncomment-12751631)  
+  *Nota: A la fecha de este commit, la discusión se encuentra en su segunda semana.*
+
+## Contribuciones
+
+Si conoces otros recursos útiles para la certificación GitHub, ¡no dudes en agregarlos mediante un pull request!


### PR DESCRIPTION
This pull request adds a new section to the `README.md` file and introduces a new file, `recursos.md`, which provides useful resources for GitHub certification. The most important changes include the addition of a resources section in the `README.md` and the detailed compilation of certification resources in `recursos.md`.

### Documentation updates:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R19-R22): Added a new "Recursos" section with a link to `recursos.md` for GitHub certification resources.

### New resource file:

* [`recursos.md`](diffhunk://#diff-724f8414f4d421befee7056fc577b72deb3658f419f1785bc5134f4128e0d5a0R1-R28): Created a new file that compiles various useful resources for preparing for GitHub certification, including important links, study guides, exam manuals, and community discussions.